### PR TITLE
fix(paco_lt.py): Fix spelling errors in code

### DIFF
--- a/PaCo-codebase/paco_lt.py
+++ b/PaCo-codebase/paco_lt.py
@@ -491,7 +491,7 @@ def train(train_loader, model, criterion, optimizer, epoch, scaler, args):
             optimizer.step()
         else:
             scaler.scale(loss).backward()
-            scaler.step(optimier)
+            scaler.step(optimizer)
             scaler.update()
 
 


### PR DESCRIPTION
Fix spelling errors: change "optimier" to "optimizer" in code